### PR TITLE
style(eslint): remove unneeded eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,3 @@
 {
-	"extends": "@sapphire",
-	"rules": {
-		"no-duplicate-imports": "off"
-	}
+	"extends": "@sapphire"
 }


### PR DESCRIPTION
`@sapphire/eslint-config` v4.0.5 has this rule disabled by default. Quick question: why are all of these eslint dependencies downloaded when they're downloaded in the config anyways?
![image](https://user-images.githubusercontent.com/65814829/143339196-056dcda7-c9a9-4720-9065-6975309ce6ef.png)

Asking because my github ci mysteriously is failing and idk if I needed to have those deps?

![image](https://user-images.githubusercontent.com/65814829/143339770-cbe8ed0c-cbab-447e-9d72-fbb0b63aa835.png)
