### PR TITLE
feat: update Spectera link

### DIFF
--- a/src/tags/tags.toml
+++ b/src/tags/tags.toml
@@ -35,7 +35,7 @@ content = """
 - [**Pengu**](<https://github.com/PenguBot/bot-sapphire>)
 - [**RTByte** **²** **³** **⁴** **ⱽ²**](<https://github.com/RTByte/rtbyte>)
 - [**Sapphire**](<https://github.com/KunoichiZ/Sapphire>)
-- [**SpecteraTS** **¹** **³** **⁴** **ⱽ²**](<https://github.com/Spectera-bot/SpecteraTS>)
+- [**Spectera** **¹** **²** **³** **⁴** **ⱽ²**](<https://github.com/SpecteraLabs/Spectera>)
 - [**Skyra** **³** **⁴** **⁵** **ⱽ²**](<https://github.com/skyra-project/skyra>)
 - [**Syrus** **ᴶˢ**](<https://github.com/syrus-bot/syrus-bot>)
 - [**Varrock-Stray-Dog** **⁵**](<https://github.com/Varrock-Stray-Dog/Varrock-Stray-Dog>)


### PR DESCRIPTION
Spectera's org name has been changed thereby resulting in a 404 and i added ² because it does use docker for production