### PR TITLE
fix(tags): removed broken bot link

### DIFF
--- a/src/tags/tags.toml
+++ b/src/tags/tags.toml
@@ -31,7 +31,6 @@ content = """
 - [**Evlyn** **⁵**](<https://github.com/skyra-project/evlyn>)
 - [**Godfather** **¹** **³** **⁵**](<https://github.com/Stitch07/godfather>)
 - [**Materia** **²** **⁴** **ⱽ²**](<https://github.com/RealShadowNova/materia>)
-- [**Olivia**](<https://github.com/Chiitoi/Olivia>)
 - [**Pengu**](<https://github.com/PenguBot/bot-sapphire>)
 - [**RTByte** **²** **³** **⁴** **ⱽ²**](<https://github.com/RTByte/rtbyte>)
 - [**Sapphire**](<https://github.com/KunoichiZ/Sapphire>)


### PR DESCRIPTION
removed the Olivia bot from the bot list as it appears the bot has been deleted / made private.