### PR TITLE
chore(tags): removed dead bot link

### DIFF
--- a/src/tags/tags.toml
+++ b/src/tags/tags.toml
@@ -27,7 +27,6 @@ content = """
 
 - [**Alestra** **⁵**](<https://github.com/skyra-project/alestra>)
 - [**Archangel** **¹** **²** **⁴** **⁵** **ⱽ²**](<https://github.com/favware/archangel>)
-- [**Dasby**](<https://github.com/dasby-project/Dasby>)
 - [**Evlyn** **⁵**](<https://github.com/skyra-project/evlyn>)
 - [**Godfather** **¹** **³** **⁵**](<https://github.com/Stitch07/godfather>)
 - [**Materia** **²** **⁴** **ⱽ²**](<https://github.com/RealShadowNova/materia>)


### PR DESCRIPTION
This project moved its location to [here](https://github.com/sdfsdfddfdddffdssfffdsdff/Ian), listed it as "dead" in the README, and archived it. After closer inspection, there's not actually much content in the code, so I don't think it was contributing much as an example. If it is decided not to remove it, the link should still be changed (and the name, probably, too).